### PR TITLE
Better frontend build system

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -68,3 +68,6 @@ spotless {
 		}
 	}
 }
+tasks.getByName<org.springframework.boot.gradle.tasks.bundling.BootJar>("bootJar") {
+	this.archiveFileName.set("backend.jar")
+}

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -11,6 +11,10 @@
 # production
 /build
 
+/backend/backend.exe
+/backend/backend.jar
+/backend/backend
+
 # misc
 .DS_Store
 .env.local

--- a/frontend/backend/copy-backend.js
+++ b/frontend/backend/copy-backend.js
@@ -1,0 +1,35 @@
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const platform = os.platform();
+const isDev = process.env.NODE_ENV !== 'production';
+
+const backendBuildDir = isDev
+  ? path.resolve(__dirname, '../../backend/build/libs')
+  : path.resolve(__dirname, '../../backend/build/native/nativeCompile');
+
+const backendBinDir = path.resolve(__dirname);
+
+let binaryName;
+if (isDev) {
+  binaryName = "backend.jar";
+} else {
+  binaryName = platform === 'win32' ? 'backend.exe' : 'backend';
+}
+
+const sourceBinary = path.join(backendBuildDir, binaryName);
+const destBinary = path.join(backendBinDir, binaryName);
+
+if (!fs.existsSync(sourceBinary)) {
+  console.error(`Backend binary not found at ${sourceBinary}`);
+  process.exit(1);
+}
+
+// Ensure destination dir exists
+if (!fs.existsSync(backendBinDir)) {
+  fs.mkdirSync(backendBinDir, { recursive: true });
+}
+
+fs.copyFileSync(sourceBinary, destBinary);
+console.log(`Copied backend binary to ${destBinary}`);

--- a/frontend/electron/main.ts
+++ b/frontend/electron/main.ts
@@ -23,7 +23,7 @@ function createWindow() {
         const jarName ="backend.jar";
         const backendPath = path.join(__dirname, '../..', 'backend', jarName);
 
-        child = require('child_process').spawn('java', ['-jar', backendPath]);
+        child = require('child_process').spawn('java', ['-jar', backendPath]); // NOSONAR
     } else {
         win.loadURL(`file://${__dirname}/../index.html`);
 

--- a/frontend/electron/main.ts
+++ b/frontend/electron/main.ts
@@ -19,32 +19,34 @@ function createWindow() {
 
     if (isDev) {
         win.loadURL('http://localhost:3000/index.html');
-        const jarPath = path.join(__dirname, '..', 'backendJar/', 'backend.jar') 
-        child = require('child_process').spawn('java', ['-jar', jarPath]);
+        
+        const jarName ="backend.jar";
+        const backendPath = path.join(__dirname, '../..', 'backend', jarName);
 
-        child.stdout.on('data', (data) => {
-        console.log(`[JAR STDOUT]: ${data}`);
-        });
-        child.stderr.on('data', (data) => {
-            console.error(`[JAR STDERR]: ${data}`);
-        });
-        child.on('error', (err) => {
-            console.error('Failed to start subprocess:', err);
-        });
-        child.on('exit', (code) => {
-            console.log(`JAR exited with code ${code}`);
-        });
-
-
+        child = require('child_process').spawn('java', ['-jar', backendPath]);
     } else {
-        // 'build/index.html'
         win.loadURL(`file://${__dirname}/../index.html`);
-        // spawn java child process running backend jar
-        const jarPath = path.join(process.resourcesPath, 'backend.jar');
-        child = require('child_process').spawn( 'java', ['-jar', jarPath, ''] );
+
+        const binaryName = process.platform === 'win32' ? 'backend.exe' : 'myserver';
+        const backendPath = path.join(process.resourcesPath, 'backend', binaryName);
+
+        child = require('child_process').spawn(backendPath);    
     }
 
     win.on('closed', () => (win = null));
+    
+    child.stdout.on('data', (data) => {
+        console.log(`[BACKEND STDOUT]: ${data}`);
+    });
+    child.stderr.on('data', (data) => {
+        console.error(`[BACKEND STDERR]: ${data}`);
+    });
+    child.on('error', (err) => {
+        console.error('Failed to start backend subprocess:', err);
+    });
+    child.on('exit', (code) => {
+        console.log(`Backend exited with code ${code}`);
+    });
 
     // Hot Reloading
     if (isDev) {

--- a/frontend/electron/main.ts
+++ b/frontend/electron/main.ts
@@ -27,7 +27,7 @@ function createWindow() {
     } else {
         win.loadURL(`file://${__dirname}/../index.html`);
 
-        const binaryName = process.platform === 'win32' ? 'backend.exe' : 'myserver';
+        const binaryName = process.platform === 'win32' ? 'backend.exe' : 'backend';
         const backendPath = path.join(process.resourcesPath, 'backend', binaryName);
 
         child = require('child_process').spawn(backendPath);    

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -48,11 +48,11 @@
         "eject": "react-scripts eject",
         "pretty": "prettier --write \"./**/*.{js,jsx,json,ts,tsx}\"",
         "postinstall": "electron-builder install-app-deps",
-        "electron:dev": "yarn build-backend:dev && yarn copy-backend:dev &&concurrently \"cross-env BROWSER=none yarn start\" \"wait-on http://localhost:3000 && tsc -p electron -w\" \"wait-on http://localhost:3000 && tsc -p electron && electron .\"",
+        "electron:dev": "yarn build-backend:dev && yarn copy-backend &&concurrently \"cross-env BROWSER=none yarn start\" \"wait-on http://localhost:3000 && tsc -p electron -w\" \"wait-on http://localhost:3000 && tsc -p electron && electron .\"",
         "build-backend": "cd ../backend && ./gradlew nativeCompile",
         "build-backend:dev": "cd ../backend && ./gradlew bootJar",
-        "copy-backend": "node backend/copy-backend.js",
-        "copy-backend:dev": "node backend/copy-backend-dev.js",
+        "copy-backend": "cross-env NODE_ENV=development node backend/copy-backend.js",
+        "copy-backend:dev": "cross-env NODE_ENV=development node backend/copy-backend.js",
         "electron:build": "yarn build-backend && yarn copy-backend && yarn build && tsc -p electron && electron-builder"    },
     "eslintConfig": {
         "extends": [

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,8 +14,8 @@
         },
         "extraResources": [
             {
-                "from": "backendJar",
-                "to": "."
+                "from": "backend",
+                "to": "backend"
             }
         ]
     },
@@ -48,9 +48,12 @@
         "eject": "react-scripts eject",
         "pretty": "prettier --write \"./**/*.{js,jsx,json,ts,tsx}\"",
         "postinstall": "electron-builder install-app-deps",
-        "electron:dev": "concurrently \"cross-env BROWSER=none yarn start\" \"wait-on http://localhost:3000 && tsc -p electron -w\" \"wait-on http://localhost:3000 && tsc -p electron && electron .\"",
-        "electron:build": "yarn build && tsc -p electron && electron-builder"
-    },
+        "electron:dev": "yarn build-backend:dev && yarn copy-backend:dev &&concurrently \"cross-env BROWSER=none yarn start\" \"wait-on http://localhost:3000 && tsc -p electron -w\" \"wait-on http://localhost:3000 && tsc -p electron && electron .\"",
+        "build-backend": "cd ../backend && ./gradlew nativeCompile",
+        "build-backend:dev": "cd ../backend && ./gradlew bootJar",
+        "copy-backend": "node backend/copy-backend.js",
+        "copy-backend:dev": "node backend/copy-backend-dev.js",
+        "electron:build": "yarn build-backend && yarn copy-backend && yarn build && tsc -p electron && electron-builder"    },
     "eslintConfig": {
         "extends": [
             "react-app",


### PR DESCRIPTION
With this new change:

`electron:dev` builds a bootable backend jar file and puts it in frontend/backend folder. Then we run it using jre on electron startup

`electron:build` builds backend as native binary (.exe on windows) and puts it in frontend/backend folder. Then we run it as a binary on electron startup

The reason why we use jar on dev is that compiling backend to native binary takes about 2min on my machine (12 threads, 32GB) which is considerably high when developing. Bootable jar is compiled in less than a second

To use electron:build on Windows you need Visual Studio Build Tool.
Follow these steps:
- https://medium.com/graalvm/using-graalvm-and-native-image-on-windows-10-9954dc071311 (build tools download link: https://download.visualstudio.microsoft.com/download/pr/fd84d0bb-e8dd-4174-b4ad-b2556426fe65/06757ecc8489159c8971ec9a1a0adab0de40807e08d160cd3144be4f64afe555/vs_BuildTools.exe)
- https://stackoverflow.com/a/77527818 (if above step is not enough)