### PR TITLE
[BOARD] Question repetition

### DIFF
--- a/backend/src/main/kotlin/com/wuji/backend/player/state/BoardPlayer.kt
+++ b/backend/src/main/kotlin/com/wuji/backend/player/state/BoardPlayer.kt
@@ -14,6 +14,7 @@ class BoardPlayerDetails(
         },
     val askedQuestions: MutableList<Question> = mutableListOf(),
     var firstGetCurrentQuestionTime: Long? = null,
+    var currentQuestion: Question? = null,
     var points: Int = 0,
 ) : PlayerDetails()
 


### PR DESCRIPTION
Once a user retrieved a question, it will be repeated in every subsequent call to get a question until he answers it.
For: https://github.com/wuji-solutions/clients-name-1/issues/71
The currentQuestion property will also be useful for https://github.com/wuji-solutions/clients-name-1/issues/70