### PR TITLE
[REPORTS] Make reports open easily in Excel

### DIFF
--- a/backend/src/main/kotlin/com/wuji/backend/reports/PlayerSpecificReport.kt
+++ b/backend/src/main/kotlin/com/wuji/backend/reports/PlayerSpecificReport.kt
@@ -1,6 +1,5 @@
 package com.wuji.backend.reports
 
-import com.github.doyaaaaaken.kotlincsv.dsl.csvWriter
 import com.wuji.backend.config.GameConfig
 import com.wuji.backend.game.common.AbstractGame
 import com.wuji.backend.player.state.Player
@@ -48,7 +47,7 @@ object PlayerSpecificReport : Report {
         val file = File(getPlayersReportsSubdir(game), fileName)
         file.createNewFile()
 
-        csvWriter().open(file) {
+        getWriter().open(file) {
             writeRow(rowNames)
 
             player.details.answers.forEach { answer ->

--- a/backend/src/main/kotlin/com/wuji/backend/reports/PlayersSummaryReport.kt
+++ b/backend/src/main/kotlin/com/wuji/backend/reports/PlayersSummaryReport.kt
@@ -1,6 +1,5 @@
 package com.wuji.backend.reports
 
-import com.github.doyaaaaaken.kotlincsv.dsl.csvWriter
 import com.wuji.backend.config.GameConfig
 import com.wuji.backend.game.common.AbstractGame
 import com.wuji.backend.player.state.PlayerDetails
@@ -20,13 +19,13 @@ object PlayersSummaryReport : Report {
         val rowNames =
             listOf(
                 "Pseudonim",
-                "Czas spędzony odpowiadając na pytanie [s]",
+                "Czas spędzony odpowiadając na pytania [s]",
                 "Liczba prawidłowych odpowiedzi",
                 "Liczba nieprawidłowych odpowiedzi",
                 "Procent poprawnych odpowiedzi [%]")
         val file = File(getGameSubdir(game), PLAYERS_SUMMARY_REPORT_FILENAME)
         file.createNewFile()
-        csvWriter().open(file) {
+        getWriter().open(file) {
             writeRow(rowNames)
             players.forEach { player ->
                 val correctCount =

--- a/backend/src/main/kotlin/com/wuji/backend/reports/QuestionsSummaryReport.kt
+++ b/backend/src/main/kotlin/com/wuji/backend/reports/QuestionsSummaryReport.kt
@@ -1,6 +1,5 @@
 package com.wuji.backend.reports
 
-import com.github.doyaaaaaken.kotlincsv.dsl.csvWriter
 import com.wuji.backend.config.GameConfig
 import com.wuji.backend.game.GameType
 import com.wuji.backend.game.board.BoardGame
@@ -46,7 +45,7 @@ object QuestionsSummaryReport : Report {
         val file = File(getGameSubdir(game), QUESTIONS_SUMMARY_REPORT_FILENAME)
         file.createNewFile()
 
-        csvWriter().open(file) {
+        getWriter().open(file) {
             writeRow(rowNames)
             questions.forEach { question ->
                 val (correctCount, incorrectCount) =

--- a/backend/src/main/kotlin/com/wuji/backend/reports/common/Report.kt
+++ b/backend/src/main/kotlin/com/wuji/backend/reports/common/Report.kt
@@ -1,9 +1,16 @@
 package com.wuji.backend.reports.common
 
+import com.github.doyaaaaaken.kotlincsv.client.CsvWriter
+import com.github.doyaaaaaken.kotlincsv.dsl.csvWriter
 import com.wuji.backend.config.GameConfig
 import com.wuji.backend.game.common.AbstractGame
 import com.wuji.backend.player.state.PlayerDetails
 
-fun interface Report {
+interface Report {
     fun write(game: AbstractGame<out PlayerDetails, out GameConfig>)
+
+    fun getWriter(): CsvWriter = csvWriter {
+        delimiter = ';'
+        charset = "Windows-1250"
+    }
 }


### PR DESCRIPTION
Now you just need to open the file with Excel and it should be a properly aligned table. No need to import as csv

Unfortunately, Excel uses different delimeters based on your location/region (XD, https://superuser.com/a/1222081). So idk in how many countries this will work. Excel also uses region-based charset, which in Eastern Europe is Windows-1250. If we use utf-8, the Excel will still try to open it with Windows-1250 *XD*