### PR TITLE
[BUG] FIx token timeout

### DIFF
--- a/backend/src/main/kotlin/com/wuji/backend/security/auth/PlayerAuthService.kt
+++ b/backend/src/main/kotlin/com/wuji/backend/security/auth/PlayerAuthService.kt
@@ -29,6 +29,7 @@ class PlayerAuthService(private val sessionRegistry: SessionRegistry) {
 
         val session = request.getSession(true)
         session.setAttribute("SPRING_SECURITY_CONTEXT", securityContext)
+        session.maxInactiveInterval = -1
         sessionRegistry.registerNewSession(session.id, participant)
 
         return participant


### PR DESCRIPTION
We don't want to invalidate a session due to inactivity, which happens by default:

> Specifies the time, in seconds, between client requests before the servlet container will invalidate this session. A zero or negative time indicates that the session should never timeout.
