### PR TITLE
[FEATURE] Session status endpoint + JSESSION cookie not HTTP-Only

### DIFF
--- a/backend/src/main/kotlin/com/wuji/backend/admin/AdminController.kt
+++ b/backend/src/main/kotlin/com/wuji/backend/admin/AdminController.kt
@@ -40,6 +40,7 @@ class AdminController(
             requestDto.name,
             requestDto.config.toQuizConfig(),
             requestDto.questions)
+        authService.clearAllSessions()
         return ResponseEntity.ok().build()
     }
 
@@ -52,6 +53,7 @@ class AdminController(
             requestDto.config.toBoardConfig(),
             requestDto.questionsFilePath,
             requestDto.numberOfTiles)
+        authService.clearAllSessions()
         return ResponseEntity.ok().build()
     }
 

--- a/backend/src/main/kotlin/com/wuji/backend/security/SecurityConfig.kt
+++ b/backend/src/main/kotlin/com/wuji/backend/security/SecurityConfig.kt
@@ -27,7 +27,9 @@ class SecurityConfig(
         listOf(
             AntPathRequestMatcher("/sse/events"),
             AntPathRequestMatcher("/sse/board/new-state"),
-            AntPathRequestMatcher("/games/*/**"))
+            AntPathRequestMatcher("/games/*/**"),
+            AntPathRequestMatcher("/security/session-status"),
+        )
 
     private final val publicAuthorized =
         listOf(AntPathRequestMatcher("/games/*/join", "POST"))

--- a/backend/src/main/kotlin/com/wuji/backend/security/SecurityController.kt
+++ b/backend/src/main/kotlin/com/wuji/backend/security/SecurityController.kt
@@ -1,0 +1,17 @@
+package com.wuji.backend.security
+
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.Authentication
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/security")
+class SecurityController {
+
+    @GetMapping("/session-status")
+    fun sessionStatus(auth: Authentication): ResponseEntity<Any> {
+        return ResponseEntity.ok().build()
+    }
+}

--- a/backend/src/main/kotlin/com/wuji/backend/security/auth/PlayerAuthService.kt
+++ b/backend/src/main/kotlin/com/wuji/backend/security/auth/PlayerAuthService.kt
@@ -48,6 +48,15 @@ class PlayerAuthService(private val sessionRegistry: SessionRegistry) {
             sessionRegistry.allPrincipals.remove(principal)
         }
     }
+
+    fun clearAllSessions() {
+        sessionRegistry.allPrincipals.forEach { principal ->
+            sessionRegistry.getAllSessions(principal, false).forEach {
+                sessionRegistry.removeSessionInformation(it.sessionId)
+                it.expireNow()
+            }
+        }
+    }
 }
 
 data class Participant(val index: Int, val nickname: String)

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,2 +1,3 @@
 spring.application.name=backend
 server.servlet.session.persistent=false
+server.servlet.session.cookie.http-only=false


### PR DESCRIPTION
This is to fix the case, when admin creates multiple games in one app run. Now, each game created will clear all the previous sessions. The endpoint is per @Trechu request for frontend to easily identify if someone's session is valid.

The endpoint will respond with 200 if everything is ok and with 401 if your session is invalid/you dont have one